### PR TITLE
override rollup version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,10 @@
     "tailwindcss": "4.1.11",
     "typescript": "5.8.3",
     "vite": "7.0.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "rollup": "4.43.0"
+    }
   }
 }


### PR DESCRIPTION
I found this was necessary for the linux build, but I don't know why